### PR TITLE
Migrate routes to native classes

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,9 +1,10 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 
-export default Route.extend({
-  session: service(),
+export default class ApplicationRoute extends Route {
+  @service session;
+
   model() {
     return this.session.initSession();
-  },
-});
+  }
+}

--- a/app/routes/article.js
+++ b/app/routes/article.js
@@ -1,11 +1,11 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 
-export default Route.extend({
-  session: service(),
-  store: service(),
+export default class ArticleRoute extends Route {
+  @service session;
+  @service store;
 
   model({ slug }) {
     return this.store.findRecord('article', slug);
-  },
-});
+  }
+}

--- a/app/routes/editor/article.js
+++ b/app/routes/editor/article.js
@@ -1,7 +1,7 @@
 import NewRoute from './new';
 
-export default NewRoute.extend({
+export default class EditorArticleRoute extends NewRoute {
   model({ slug }) {
     return this.store.findRecord('article', slug);
-  },
-});
+  }
+}

--- a/app/routes/editor/new.js
+++ b/app/routes/editor/new.js
@@ -1,12 +1,12 @@
-import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import window from 'ember-window-mock';
 
-export default Route.extend({
-  session: service(),
-  store: service(),
-
-  templateName: 'editor/new',
+export default class NewRoute extends Route {
+  @service session;
+  @service store;
+  templateName = 'editor/new';
 
   /**
    * Only authenticated users are allowed to visit this page.
@@ -17,47 +17,46 @@ export default Route.extend({
     if (!this.session.isLoggedIn) {
       this.transitionTo('login');
     }
-  },
+  }
 
   /**
    * Create a new article record used in the page.
    */
   model() {
     return this.store.createRecord('article');
-  },
+  }
 
-  actions: {
+  /**
+   * If there are changes to the article, confirm with the user before transitioning.
+   * If user continues to transition routes, rollback the changes.
+   * Rollback changes will unload it from the store if the article is new.
+   */
+  @action
+  async willTransition(transition) {
+    const { draftArticle } = this.controller;
+    let shouldRollbackAttributes = false;
+
     /**
-     * If there are changes to the article, confirm with the user before transitioning.
-     * If user continues to transition routes, rollback the changes.
-     * Rollback changes will unload it from the store if the article is new.
+     * If there are dirty attributes, comfirm with user whether they want to leave withou saving.
+     * Otherwise, just roll back the model attributes, which will unload it from the store.
      */
-    async willTransition(transition) {
-      const { draftArticle } = this.controller;
-      let shouldRollbackAttributes = false;
-
-      /**
-       * If there are dirty attributes, comfirm with user whether they want to leave withou saving.
-       * Otherwise, just roll back the model attributes, which will unload it from the store.
-       */
-      if (draftArticle.hasDirtyAttributes) {
-        if (window.confirm('You have not created the article. Are you sure you want to leave?')) {
-          shouldRollbackAttributes = true;
-        } else {
-          transition.abort();
-        }
-      } else {
+    if (draftArticle.hasDirtyAttributes) {
+      if (window.confirm('You have not created the article. Are you sure you want to leave?')) {
         shouldRollbackAttributes = true;
+      } else {
+        transition.abort();
       }
+    } else {
+      shouldRollbackAttributes = true;
+    }
 
-      if (!transition.isAborted && shouldRollbackAttributes) {
-        /**
-         * Rollback attributes after transition to prevent the article content in the form to flash.
-         */
-        await transition;
+    if (!transition.isAborted && shouldRollbackAttributes) {
+      /**
+       * Rollback attributes after transition to prevent the article content in the form to flash.
+       */
+      await transition;
 
-        draftArticle.rollbackAttributes();
-      }
-    },
-  },
-});
+      draftArticle.rollbackAttributes();
+    }
+  }
+}

--- a/app/routes/home.js
+++ b/app/routes/home.js
@@ -1,9 +1,10 @@
-import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 
-export default Route.extend({
-  session: service(),
-  queryParams: {
+export default class HomeRoute extends Route {
+  @service session;
+
+  queryParams = {
     feed: {
       refreshModel: true,
     },
@@ -13,7 +14,7 @@ export default Route.extend({
     page: {
       refreshModel: true,
     },
-  },
+  };
 
   async model({ feed, page, tag }) {
     const NUMBER_OF_ARTICLES = 10;
@@ -32,5 +33,5 @@ export default Route.extend({
       articles.meta.pageSize = NUMBER_OF_ARTICLES;
       return { articles, meta: articles.meta };
     }
-  },
-});
+  }
+}

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class ProfileRoute extends Route {
   model({ id }) {
     return this.store.findRecord('profile', id);
-  },
-});
+  }
+}

--- a/app/routes/profile/favorites.js
+++ b/app/routes/profile/favorites.js
@@ -1,11 +1,12 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-  templateName: 'profile/index',
+export default class ProfileFavoritesRoute extends Route {
+  templateName = 'profile/index';
+
   async afterModel(profile) {
     /**
      * Reload the data when visiting the route, otherwise the data remains stale.
      */
-    await profile.get('favoriteArticles').reload();
-  },
-});
+    await profile.favoriteArticles.reload();
+  }
+}

--- a/app/routes/profile/index.js
+++ b/app/routes/profile/index.js
@@ -1,10 +1,10 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class IndexRoute extends Route {
   async afterModel(profile) {
     /**
      * Reload the data when visiting the route, otherwise the data remains stale.
      */
-    await profile.get('articles').reload();
-  },
-});
+    await profile.articles.reload();
+  }
+}


### PR DESCRIPTION
Fixes #6 

Used the [ember native class codemod](https://github.com/ember-codemods/ember-native-class-codemod)

Ran the following command and tweaked to remove the injected `@classic` decorators

```
npx ember-native-class-codemod http://localhost:4200 app/routes
```