### PR TITLE
Migrate services to native classes

### DIFF
--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setupLoggedInUser, setupLoggedOutUser } from 'ember-octane-realworld/tests/helpers/user';
 
-const STORAGE_KEY = 'realworld.ember-classic.token';
+const STORAGE_KEY = 'realworld.ember-octane.token';
 
 module('Unit | Service | session', function(hooks) {
   setupTest(hooks);


### PR DESCRIPTION
Fixes #5 

Used the [ember native class codemod](https://github.com/ember-codemods/ember-native-class-codemod)

Ran the following command and tweaked to remove the injected `@classic` decorators

```
npx ember-native-class-codemod http://localhost:4200 app/services
```